### PR TITLE
Add LIMIT keyword

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -5,9 +5,9 @@ use std::iter::Peekable;
 pub enum LexItem {
   Identifier(String),
   Str(String),
-  Equals(char),
+  Equals,
   Number(i64),
-  Comma(char)
+  Comma
 }
 
 fn consume_string<T: Iterator<Item = char>>(iter: &mut Peekable<T>) -> String {
@@ -68,11 +68,11 @@ pub fn tokenize(input: &String) -> Result<Vec<LexItem>, String> {
         it.next();
       },
       '=' => {
-        result.push(LexItem::Equals('='));
+        result.push(LexItem::Equals);
         it.next();
       },
       ',' => {
-        result.push(LexItem::Comma(','));
+        result.push(LexItem::Comma);
         it.next();
       },
       ' ' => { it.next(); },
@@ -113,7 +113,7 @@ mod tests {
 
     assert_eq!(results[4], super::LexItem::Identifier("WHERE".into()));
     assert_eq!(results[5], super::LexItem::Identifier("type".into()));
-    assert_eq!(results[6], super::LexItem::Equals('='.into()));
+    assert_eq!(results[6], super::LexItem::Equals);
     assert_eq!(results[7], super::LexItem::Str("error".into()));
   }
 
@@ -134,9 +134,9 @@ mod tests {
     let results = tokenize(&"SELECT type, date, severity FROM 'app.log' LIMIT 10".into()).unwrap();
     assert_eq!(results[0], super::LexItem::Identifier("SELECT".into()));
     assert_eq!(results[1], super::LexItem::Identifier("type".into()));
-    assert_eq!(results[2], super::LexItem::Comma(','.into()));
+    assert_eq!(results[2], super::LexItem::Comma);
     assert_eq!(results[3], super::LexItem::Identifier("date".into()));
-    assert_eq!(results[4], super::LexItem::Comma(','.into()));
+    assert_eq!(results[4], super::LexItem::Comma);
     assert_eq!(results[5], super::LexItem::Identifier("severity".into()));
     assert_eq!(results[6], super::LexItem::Identifier("FROM".into()));
     assert_eq!(results[7], super::LexItem::Str("app.log".into()));

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -3,41 +3,42 @@ use std::iter::Peekable;
 #[derive(Debug)]
 #[derive(PartialEq)]
 pub enum LexItem {
-  Identifier(String),
-  Str(String),
-  Equals,
-  Number(i64),
-  Comma
+    Identifier(String),
+    Str(String),
+    Equals,
+    Number(i64),
+    Comma,
+    EOF
 }
 
 fn consume_string<T: Iterator<Item = char>>(iter: &mut Peekable<T>) -> String {
-  let mut resulting_str = String::from("");
+    let mut resulting_str = String::from("");
 
-  while let Some(ch) = iter.peek().map(|c| *c) {
-    if ch == '\'' {
-      break;
-    } else {
-      resulting_str.push(ch.clone());
-      iter.next();
+    while let Some(ch) = iter.peek().map(|c| *c) {
+        if ch == '\'' {
+            break;
+        } else {
+            resulting_str.push(ch.clone());
+            iter.next();
+        }
     }
-  }
 
-  resulting_str
+    resulting_str
 }
 
 fn consume_identifier<T: Iterator<Item = char>>(iter: &mut Peekable<T>) -> String {
-  let mut resulting_str = String::from("");
+    let mut resulting_str = String::from("");
 
-  while let Some(ch) = iter.peek().map(|c| *c) {
-    if ch.is_alphabetic() {
-      resulting_str.push(ch.clone());
-      iter.next();
-    } else {
-      break;
+    while let Some(ch) = iter.peek().map(|c| *c) {
+        if ch.is_alphabetic() {
+            resulting_str.push(ch.clone());
+            iter.next();
+        } else {
+            break;
+        }
     }
-  }
 
-  resulting_str
+    resulting_str
 }
 
 fn consume_number<T: Iterator<Item = char>>(c: char, iter: &mut Peekable<T>) -> i64 {
@@ -50,97 +51,105 @@ fn consume_number<T: Iterator<Item = char>>(c: char, iter: &mut Peekable<T>) -> 
 }
 
 pub fn tokenize(input: &String) -> Result<Vec<LexItem>, String> {
-  let mut result = Vec::new();
+    let mut result = Vec::new();
 
-  let mut it = input.chars().peekable();
+    let mut it = input.chars().peekable();
 
-  while let Some(&ch) = it.peek() {
-    match ch {
-      '0'...'9' => {
-        it.next();
-        let n = consume_number(ch, &mut it);
-        result.push(LexItem::Number(n));
-      },
-      '\'' => {
-        it.next();
-        let string = consume_string(&mut it);
-        result.push(LexItem::Str(string));
-        it.next();
-      },
-      '=' => {
-        result.push(LexItem::Equals);
-        it.next();
-      },
-      ',' => {
-        result.push(LexItem::Comma);
-        it.next();
-      },
-      ' ' => { it.next(); },
-      _ => {
-        if ch.is_alphabetic() {
-          let string = consume_identifier(&mut it);
-          result.push(LexItem::Identifier(string));
-        } else {
-          return Err(format!("Unexpected char {}", ch));
+    while let Some(&ch) = it.peek() {
+        match ch {
+            '0'...'9' => {
+                it.next();
+                let n = consume_number(ch, &mut it);
+                result.push(LexItem::Number(n));
+            },
+            '\'' => {
+                it.next();
+                let string = consume_string(&mut it);
+                result.push(LexItem::Str(string));
+                it.next();
+            },
+            '=' => {
+                result.push(LexItem::Equals);
+                it.next();
+            },
+            ',' => {
+                result.push(LexItem::Comma);
+                it.next();
+            },
+            ' ' => { it.next(); },
+            _ => {
+                if ch.is_alphabetic() {
+                    let string = consume_identifier(&mut it);
+                    result.push(LexItem::Identifier(string));
+                } else {
+                    return Err(format!("Unexpected char {}", ch));
+                }
+            }
         }
-      }
     }
-  }
 
-  Ok(result)
+    result.push(LexItem::EOF);
+
+    Ok(result)
 }
 
 #[cfg(test)]
 mod tests {
-  use super::*;
+    use super::*;
 
-  #[test]
-  fn parse_string_consumes_until_quote() {
-    let test_str = "'app.log'";
-    let mut iter = test_str.chars().peekable();
-    iter.next();
-    let actual_str = consume_string(&mut iter);
-    assert_eq!(actual_str, "app.log");
-  }
+    #[test]
+    fn parse_string_consumes_until_quote() {
+        let test_str = "'app.log'";
+        let mut iter = test_str.chars().peekable();
+        iter.next();
+        let actual_str = consume_string(&mut iter);
+        assert_eq!(actual_str, "app.log");
+    }
 
-  #[test]
-  fn it_tokenizes_simple_select_where() {
-    let results = tokenize(&"SELECT type FROM 'app.log' WHERE type = 'error'".into()).unwrap();
-    assert_eq!(results[0], super::LexItem::Identifier("SELECT".into()));
-    assert_eq!(results[1], super::LexItem::Identifier("type".into()));
-    assert_eq!(results[2], super::LexItem::Identifier("FROM".into()));
-    assert_eq!(results[3], super::LexItem::Str("app.log".into()));
+    #[test]
+    fn it_returns_eol_when_end_of_input_is_reached() {
+        let results = tokenize(&"SELECT type FROM 'app.log' WHERE type = 'error'".into()).unwrap();
+        assert_eq!(results[8], super::LexItem::EOF);
+    }
 
-    assert_eq!(results[4], super::LexItem::Identifier("WHERE".into()));
-    assert_eq!(results[5], super::LexItem::Identifier("type".into()));
-    assert_eq!(results[6], super::LexItem::Equals);
-    assert_eq!(results[7], super::LexItem::Str("error".into()));
-  }
+    #[test]
+    fn it_tokenizes_simple_select_where() {
+        let results = tokenize(&"SELECT type FROM 'app.log' WHERE type = 'error'".into()).unwrap();
+        assert_eq!(results[0], super::LexItem::Identifier("SELECT".into()));
+        assert_eq!(results[1], super::LexItem::Identifier("type".into()));
+        assert_eq!(results[2], super::LexItem::Identifier("FROM".into()));
+        assert_eq!(results[3], super::LexItem::Str("app.log".into()));
 
-  #[test]
-  fn it_tokenizes_simple_select_with_limit() {
-    let results = tokenize(&"SELECT type FROM 'app.log' LIMIT 10".into()).unwrap();
-    assert_eq!(results[0], super::LexItem::Identifier("SELECT".into()));
-    assert_eq!(results[1], super::LexItem::Identifier("type".into()));
-    assert_eq!(results[2], super::LexItem::Identifier("FROM".into()));
-    assert_eq!(results[3], super::LexItem::Str("app.log".into()));
+        assert_eq!(results[4], super::LexItem::Identifier("WHERE".into()));
+        assert_eq!(results[5], super::LexItem::Identifier("type".into()));
+        assert_eq!(results[6], super::LexItem::Equals);
+        assert_eq!(results[7], super::LexItem::Str("error".into()));
+    }
 
-    assert_eq!(results[4], super::LexItem::Identifier("LIMIT".into()));
-    assert_eq!(results[5], super::LexItem::Number(10));
-  }
+    #[test]
+    fn it_tokenizes_simple_select_with_limit() {
+        let results = tokenize(&"SELECT type FROM 'app.log' LIMIT 10".into()).unwrap();
+        assert_eq!(results[0], super::LexItem::Identifier("SELECT".into()));
+        assert_eq!(results[1], super::LexItem::Identifier("type".into()));
+        assert_eq!(results[2], super::LexItem::Identifier("FROM".into()));
+        assert_eq!(results[3], super::LexItem::Str("app.log".into()));
 
-  #[test]
-  fn it_tokenizes_select_with_multiple_select_fields() {
-    let results = tokenize(&"SELECT type, date, severity FROM 'app.log' LIMIT 10".into()).unwrap();
-    assert_eq!(results[0], super::LexItem::Identifier("SELECT".into()));
-    assert_eq!(results[1], super::LexItem::Identifier("type".into()));
-    assert_eq!(results[2], super::LexItem::Comma);
-    assert_eq!(results[3], super::LexItem::Identifier("date".into()));
-    assert_eq!(results[4], super::LexItem::Comma);
-    assert_eq!(results[5], super::LexItem::Identifier("severity".into()));
-    assert_eq!(results[6], super::LexItem::Identifier("FROM".into()));
-    assert_eq!(results[7], super::LexItem::Str("app.log".into()));
-    assert_eq!(results[8], super::LexItem::Identifier("LIMIT".into()));
-    assert_eq!(results[9], super::LexItem::Number(10));
-  }
+        assert_eq!(results[4], super::LexItem::Identifier("LIMIT".into()));
+        assert_eq!(results[5], super::LexItem::Number(10));
+    }
+
+    #[test]
+    fn it_tokenizes_select_with_multiple_select_fields() {
+        let results = tokenize(&"SELECT type, date, severity FROM 'app.log' LIMIT 10".into()).unwrap();
+        assert_eq!(results[0], super::LexItem::Identifier("SELECT".into()));
+        assert_eq!(results[1], super::LexItem::Identifier("type".into()));
+        assert_eq!(results[2], super::LexItem::Comma);
+        assert_eq!(results[3], super::LexItem::Identifier("date".into()));
+        assert_eq!(results[4], super::LexItem::Comma);
+        assert_eq!(results[5], super::LexItem::Identifier("severity".into()));
+        assert_eq!(results[6], super::LexItem::Identifier("FROM".into()));
+        assert_eq!(results[7], super::LexItem::Str("app.log".into()));
+        assert_eq!(results[8], super::LexItem::Identifier("LIMIT".into()));
+        assert_eq!(results[9], super::LexItem::Number(10));
+    }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -381,4 +381,12 @@ mod tests {
         assert_eq!(left_result_node.entry, GrammarItem::Condition { field: "title".into(), value: "Network connection failed".into() });
         assert_eq!(right_result_node.entry, GrammarItem::Limit { number_of_rows: 10, direction: LimitDirection::Last });
     }
+
+    #[test]
+    fn it_returns_error_for_query_with_limit_and_where_in_the_wrong_order() {
+        let query = "SELECT title, severity FROM 'app.log' LIMIT LAST 10 WHERE title = 'Network connection failed'".into();
+        let mut parser = Parser::new(query);
+        let expected_err = parser.parse();
+        assert!(expected_err.is_err());
+    }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -64,7 +64,7 @@ impl Parser {
     fn expect_equals(&self) -> Result<(), String> {
         if let Some(current_token) = self.current_token() {
             match *current_token {
-                lexer::LexItem::Equals(_) => {
+                lexer::LexItem::Equals => {
                     Ok(())
                 },
                 _ => {
@@ -148,7 +148,7 @@ impl Parser {
                         }
                     }
                 },
-                Some(&LexItem::Comma(_)) => {
+                Some(&LexItem::Comma) => {
                     if let Some(&LexItem::Identifier(ref possible_from)) = self.next_token() {
                         if possible_from == "FROM" {
                             return Err("Expected Identifier, got keyword FROM".into());


### PR DESCRIPTION
This PR ships with support for the `LIMIT` keyword. This helps to reduce the number of returned lines to a custom value. 
It is possible to either get the first `n` lines via `LIMIT n` or the last `n` lines via `LIMIT LAST n`.

It is also possible to parse queries which don't have a `WHERE` clause and a `LIMIT` so they look like this:

```
SELECT title FROM 'app.log'
```

A `LIMIT` however must always appear last in a query. It's not possible to first have a `LIMIT` and then a `WHERE`.

