### PR TITLE
feat: limit ast node returns an usize

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -6,7 +6,7 @@ pub enum LexItem {
     Identifier(String),
     Str(String),
     Equals,
-    Number(i64),
+    Number(usize),
     Comma,
     EOF
 }
@@ -41,13 +41,13 @@ fn consume_identifier<T: Iterator<Item = char>>(iter: &mut Peekable<T>) -> Strin
     resulting_str
 }
 
-fn consume_number<T: Iterator<Item = char>>(c: char, iter: &mut Peekable<T>) -> i64 {
+fn consume_number<T: Iterator<Item = char>>(c: char, iter: &mut Peekable<T>) -> usize {
     let mut number = c.to_string().parse::<i64>().expect("Expected digit");
     while let Some(Ok(digit)) = iter.peek().map(|c| c.to_string().parse::<i64>()) {
         number = number * 10 + digit;
         iter.next();
     }
-    number
+    number as usize
 }
 
 pub fn tokenize(input: &String) -> Result<Vec<LexItem>, String> {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -8,7 +8,7 @@ pub enum GrammarItem {
     Query,
     LogFile { fields: Vec<String>, filename: String },
     Condition { field: String, value: String },
-    Limit { number_of_rows: i64, direction: LimitDirection },
+    Limit { number_of_rows: usize, direction: LimitDirection },
     LogResult
 }
 
@@ -120,7 +120,7 @@ impl Parser {
         }
     }
 
-    fn expect_number(&self, expected_number: Option<i64>) -> Result<i64, String> {
+    fn expect_number(&self, expected_number: Option<usize>) -> Result<usize, String> {
         match self.current_token() {
             Some(&lexer::LexItem::Number(ref num)) => {
                 if expected_number.is_some() {
@@ -385,6 +385,14 @@ mod tests {
     #[test]
     fn it_returns_error_for_query_with_limit_and_where_in_the_wrong_order() {
         let query = "SELECT title, severity FROM 'app.log' LIMIT LAST 10 WHERE title = 'Network connection failed'".into();
+        let mut parser = Parser::new(query);
+        let expected_err = parser.parse();
+        assert!(expected_err.is_err());
+    }
+
+    #[test]
+    fn it_raises_an_error_when_limit_number_is_negative() {
+        let query = "SELECT title, severity FROM 'app.log' LIMIT LAST -10".into();
         let mut parser = Parser::new(query);
         let expected_err = parser.parse();
         assert!(expected_err.is_err());


### PR DESCRIPTION
BREAKING CHANGE: This is an backwards incompatible API change.

The `LIMIT` value should be an `usize` so we can use it more easily later on to filter data sets